### PR TITLE
Support for versioned shared dependencies

### DIFF
--- a/inttest/envcleanup/deps.rebar.config
+++ b/inttest/envcleanup/deps.rebar.config
@@ -1,0 +1,1 @@
+{deps, [shareddep]}.

--- a/inttest/envcleanup/envcleanup_rt.erl
+++ b/inttest/envcleanup/envcleanup_rt.erl
@@ -1,0 +1,55 @@
+%%% @doc Environment cleanup handling test
+%%%
+%%% This test checks if environment is cleaned up properly after a test.
+
+-module(env_test).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [
+     {copy, "../../rebar", "rebar"},
+     {copy, "rebar.config", "rebar.config"},
+
+     %% Main and included configuration file.
+     {copy, "sys.config", "config/sys.config"},
+     {copy, "extra.config", "priv/extra.config"},
+
+     %% Dummy applications with a shared dependency.
+     {create, "deps/app_a/ebin/app_a.app", app(app_a, [])},
+     {copy, "deps.rebar.config", "deps/app_a/rebar.config"},
+     {create, "deps/app_b/ebin/app_b.app", app(app_b, [])},
+     {copy, "deps.rebar.config", "deps/app_b/rebar.config"},
+
+     %% Tests that start shared dependency app.
+     {template, "eunit.erl", "deps/app_a/test/app_a_eunit.erl",
+      dict:from_list([{module, "app_a_eunit"}])},
+     {template, "eunit.erl", "deps/app_b/test/app_b_eunit.erl",
+      dict:from_list([{module, "app_b_eunit"}])},
+
+     %% Files for shared dependency dummy app.
+     {copy, "shareddep_app.erl", "deps/shareddep/src/shareddep_app.erl"},
+     {copy, "shareddep.app.src", "deps/shareddep/src/shareddep.app.src"},
+     {copy, "shareddep_sup.erl", "deps/shareddep/src/shareddep_sup.erl"}
+    ].
+
+run(_Dir) ->
+    %% Compile shareddep
+    ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
+    %% Run tests with configuration
+    Env = [{"ERL_FLAGS", "-config config/sys"}],
+    ?assertMatch({ok, _}, retest_sh:run("./rebar eunit", [{env, Env}])),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/envcleanup/eunit.erl
+++ b/inttest/envcleanup/eunit.erl
@@ -1,0 +1,12 @@
+-module({{module}}).
+-include_lib("eunit/include/eunit.hrl").
+
+%% This test is run by both app_a and app_b
+setup_test() ->
+    ?assertEqual(undefined, application:get_env(shareddep, otherkey)),
+
+    %% Start the shared dependency which modifies environment
+    ?assertEqual(ok, application:start(shareddep)),
+
+    ?assertEqual({ok, "modified env state"},
+                 application:get_env(shareddep, otherkey)).

--- a/inttest/envcleanup/extra.config
+++ b/inttest/envcleanup/extra.config
@@ -1,0 +1,3 @@
+[
+    {shareddep, [{key, "value"}]}
+].

--- a/inttest/envcleanup/rebar.config
+++ b/inttest/envcleanup/rebar.config
@@ -1,0 +1,1 @@
+{deps, [shareddep, app_a, app_b]}.

--- a/inttest/envcleanup/shareddep.app.src
+++ b/inttest/envcleanup/shareddep.app.src
@@ -1,0 +1,12 @@
+{application, shareddep,
+ [
+  {description, ""},
+  {vsn, "1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib
+                 ]},
+  {mod, { shareddep_app, []}},
+  {env, []}
+ ]}.

--- a/inttest/envcleanup/shareddep_app.erl
+++ b/inttest/envcleanup/shareddep_app.erl
@@ -1,0 +1,25 @@
+-module(shareddep_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    %% Read some key from included configuration (sys -> extra config)
+    case application:get_env(shareddep, key) of
+        {ok, Value} -> io:format(user, "Found configuration in env: ~p", [Value]);
+        _ -> throw("Could not read configuration from env!")
+    end,
+    %% Modify environment by adding another key/value.
+    %% Since the eunit suite is ran twice, in the test we assert it is cleaned
+    %% up on each consecutive test run.
+    application:set_env(shareddep, otherkey, "modified env state"),
+    shareddep_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/inttest/envcleanup/shareddep_sup.erl
+++ b/inttest/envcleanup/shareddep_sup.erl
@@ -1,0 +1,27 @@
+-module(shareddep_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, []} }.
+

--- a/inttest/envcleanup/sys.config
+++ b/inttest/envcleanup/sys.config
@@ -1,0 +1,3 @@
+[
+    "priv/extra.config"
+].

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -145,6 +145,21 @@
 
 %% == Dependencies ==
 
+%% Where to put shared dependencies. By default it is not used.  Shared
+%% dependencies contain versioned directories and result in symlinks from the
+%% deps_dir to the shared_deps_dir.  This allows you to share deps between
+%% several projects.
+%%
+%% If environment variable REBAR_COPY_FROM_SHARED_DEPS_DIR is set, rebar copies
+%% instead of symlinking.
+%%
+%% Note that if you are using same application from different repositories,
+%% you will end up using an unexpected repository. For example, project
+%% A depends on {lager, "", {git, "basho/lager", {rev, "maint"}}},
+%% B depends on {lager, "", {git, "spilgames/lager", {rev, "maint"}}},
+%% rebar will think these repositories are identical and either A or B will win.
+{shared_deps_dir, "../deps"}.
+
 %% Where to put any downloaded dependencies. Default is "deps"
 {deps_dir, "deps"}.
 

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -32,6 +32,7 @@
          app_name/2,
          app_applications/2,
          app_vsn/2,
+         app_vsn_reset/2,
          is_skipped_app/2]).
 
 -export([load_app_file/2]). % TEMPORARY
@@ -106,6 +107,18 @@ app_vsn(Config, AppFile) ->
                    [AppFile, Reason])
     end.
 
+app_vsn_reset(Config, AppFile) ->
+    case reload_app_file(Config, AppFile) of
+        {ok, Config1, _, AppInfo} ->
+            AppDir = filename:dirname(filename:dirname(AppFile)),
+            rebar_utils:vcs_vsn_delete(Config1,
+                get_value(vsn, AppInfo, AppFile), AppDir);
+        {error, Reason} ->
+            ?ABORT("Failed to extract vsn from ~s: ~p\n",
+                   [AppFile, Reason]),
+            Config
+    end.
+
 is_skipped_app(Config, AppFile) ->
     {Config1, ThisApp} = app_name(Config, AppFile),
     %% Check for apps global parameter; this is a comma-delimited list
@@ -133,6 +146,11 @@ is_skipped_app(Config, AppFile) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+reload_app_file(Config, Filename) ->
+    AppFile = {app_file, Filename},
+    erlang:put(AppFile, undefined),
+    load_app_file(Config, Filename).
 
 load_app_file(Config, Filename) ->
     AppFile = {app_file, Filename},

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -28,7 +28,7 @@
 
 -export([new/0, new/1, base_config/1, consult_file/1,
          get/3, get_local/3, get_list/3,
-         get_all/2,
+         get_all/2, get_dir/1,
          set/3,
          set_global/3, get_global/3,
          is_verbose/1,
@@ -88,6 +88,11 @@ get_local(Config, Key, Default) ->
 
 get_all(Config, Key) ->
     proplists:get_all_values(Key, Config#config.opts).
+
+get_dir(#config{dir=Dir}) ->
+    Dir;
+get_dir(_) ->
+    undefined.
 
 set(Config, Key, Value) ->
     Opts = proplists:delete(Key, Config#config.opts),

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -26,6 +26,7 @@
 %% -------------------------------------------------------------------
 -module(rebar_deps).
 
+-include_lib("kernel/include/file.hrl").
 -include("rebar.hrl").
 
 -export([preprocess/2,
@@ -56,17 +57,21 @@ preprocess(Config, _) ->
     %% top level down. Means the root deps_dir is honoured or the default
     %% used globally since it will be set on the first time through here
     Config1 = set_shared_deps_dir(Config, get_shared_deps_dir(Config, [])),
+    %% We also set a shared_deps_dir. If set, we use this to download
+    %% dependencies and then symlink from deps_dir to shared_deps_dir
+    Config2 = set_global_deps_dir(Config1,
+        rebar_config:get_global(Config1, deps_dir, [])),
 
     %% Get the list of deps for the current working directory and identify those
     %% deps that are available/present.
-    Deps = rebar_config:get_local(Config1, deps, []),
-    {Config2, {AvailableDeps, MissingDeps}} = find_deps(Config1, find, Deps),
+    Deps = rebar_config:get_local(Config2, deps, []),
+    {Config3, {AvailableDeps, MissingDeps}} = find_deps(Config2, find, Deps),
 
     ?DEBUG("Available deps: ~p\n", [AvailableDeps]),
     ?DEBUG("Missing deps  : ~p\n", [MissingDeps]),
 
     %% Add available deps to code path
-    Config3 = update_deps_code_path(Config2, AvailableDeps),
+    Config4 = update_deps_code_path(Config3, AvailableDeps),
 
     %% If skip_deps=true, mark each dep dir as a skip_dir w/ the core so that
     %% the current command doesn't run on the dep dir. However, pre/postprocess
@@ -74,12 +79,12 @@ preprocess(Config, _) ->
     %%
     %% Also, if skip_deps=comma,separated,app,list, then only the given
     %% dependencies are skipped.
-    NewConfig = case rebar_config:get_global(Config3, skip_deps, false) of
+    NewConfig = case rebar_config:get_global(Config4, skip_deps, false) of
         "true" ->
             lists:foldl(
                 fun(#dep{dir = Dir}, C) ->
                         rebar_config:set_skip_dir(C, Dir)
-                end, Config3, AvailableDeps);
+                end, Config4, AvailableDeps);
         Apps when is_list(Apps) ->
             SkipApps = [list_to_atom(App) || App <- string:tokens(Apps, ",")],
             lists:foldl(
@@ -88,9 +93,9 @@ preprocess(Config, _) ->
                             true -> rebar_config:set_skip_dir(C, Dir);
                             false -> C
                         end
-                end, Config3, AvailableDeps);
+                end, Config4, AvailableDeps);
         _ ->
-            Config3
+            Config4
     end,
 
     %% Filtering out 'raw' dependencies so that no commands other than
@@ -130,6 +135,41 @@ setup_env(Config) ->
                        {"ERL_LIBS", DepsDir ++ Separator ++ PrevValue}
                end,
     [{"REBAR_DEPS_DIR", DepsDir}, ERL_LIBS].
+
+%% Set symlinks from DEPS dir to SHARED_DEPS dir
+%% This works most Unix systems and Windows beginning with Vista
+%% We need to make sure the deps_dir actually exists before
+%% we can symlink to it
+'symlink-shared-deps-to-deps'(Config, DownloadDir, TargetDir) ->
+    {true, DepsDir} = get_deps_dir(Config),
+    ok = filelib:ensure_dir(DepsDir ++ "/"),
+    LinkResult = file:make_symlink(DownloadDir, TargetDir),
+    case LinkResult of
+        {error, enotsup} ->
+            ?ABORT("Shared deps require OS support for symlinks.\n", []);
+        ok ->
+            ?DEBUG("Symlinked ~1000p to ~1000p\n", [DownloadDir, TargetDir]);
+        _ ->
+            ?ERROR("Error symlinking ~1000p to ~1000p : ~1000p\n", [DownloadDir, TargetDir, LinkResult])
+    end,
+    LinkResult.
+
+%% Copy instead of symlink from SHARED_DEPS to DEPS dir
+'copy-shared-deps-to-deps'(Config, DownloadDir, TargetDir) ->
+    {true, DepsDir} = get_deps_dir(Config),
+    ok = filelib:ensure_dir(DepsDir ++ "/"),
+    Result = rebar_file_utils:cp_r([DownloadDir], TargetDir),
+    ?DEBUG("Copied ~1000p to ~1000p\n", [DownloadDir, TargetDir]),
+    Result.
+
+
+setup_deps_dir(Config, SharedTargetDir, TargetDir) ->
+    case rebar_config:get_global(Config, copy_from_shared_deps_dir, false) of
+        true ->
+            'copy-shared-deps-to-deps'(Config, SharedTargetDir, TargetDir);
+        _ ->    %undefined | false
+            'symlink-shared-deps-to-deps'(Config, SharedTargetDir, TargetDir)
+    end.
 
 %% common function used by 'check-deps' and 'compile'
 do_check_deps(Config) ->
@@ -186,9 +226,8 @@ do_check_deps(Config) ->
     {true, DepsDir} = get_deps_dir(Config),
     Deps = rebar_config:get_local(Config, deps, []),
     {Config1, {AvailableDeps, _}} = find_deps(Config, find, Deps),
-    _ = [delete_dep(D)
-         || D <- AvailableDeps,
-            lists:prefix(DepsDir, D#dep.dir)],
+    _ = [delete_dep(Config1, D) ||
+        D <- AvailableDeps, lists:prefix(DepsDir, D#dep.dir)],
     {ok, Config1}.
 
 'list-deps'(Config, _) ->
@@ -256,9 +295,6 @@ set_shared_deps_dir(Config, []) ->
 set_shared_deps_dir(Config, _DepsDir) ->
     Config.
 
-get_shared_deps_dir(Config, Default) ->
-    rebar_config:get_xconf(Config, deps_dir, Default).
-
 get_deps_dir(Config) ->
     get_deps_dir(Config, "").
 
@@ -267,11 +303,57 @@ get_deps_dir(Config, App) ->
     DepsDir = get_shared_deps_dir(Config, "deps"),
     {true, filename:join([BaseDir, DepsDir, App])}.
 
+%% shared_deps_dir by default is undefined.
+%% By default it will use OS environment value REBAR_SHARED_DEPS_DIR if set.
+set_global_deps_dir(Config, []) ->
+    Config1 = rebar_config:set_global(Config, deps_dir,
+                            rebar_config:get_local(Config, deps_dir, "deps")),
+
+    EnvSharedDepsDir = case os:getenv("REBAR_SHARED_DEPS_DIR") of
+                           false ->
+                                undefined;
+                           Dir ->
+                                Dir
+                       end,
+    Config2 = rebar_config:set_global(Config1, shared_deps_dir,
+        rebar_config:get_local(Config1, shared_deps_dir, EnvSharedDepsDir)),
+
+    EnvCopyFromSharedDepsDir =
+    case os:getenv("REBAR_COPY_FROM_SHARED_DEPS_DIR") of
+        "1" -> true;
+        "true" -> true;
+        _ -> false
+    end,
+
+    rebar_config:set_global(Config2, copy_from_shared_deps_dir,
+        rebar_config:get_local(Config2, copy_from_shared_deps_dir,
+            EnvCopyFromSharedDepsDir));
+
+set_global_deps_dir(Config, _DepsDir) ->
+    Config.
+
 dep_dirs(Deps) ->
     [D#dep.dir || D <- Deps].
 
 save_dep_dirs(Config, Deps) ->
     rebar_config:set_xconf(Config, ?MODULE, dep_dirs(Deps)).
+
+get_shared_deps_dir(Config, Default) ->
+    rebar_config:get_xconf(Config, deps_dir, Default).
+
+get_spil_shared_deps_dir(Config, Dep) ->
+    BaseDir = rebar_config:get_global(Config, base_dir, []),
+    SharedDepsDir = rebar_config:get_global(Config, shared_deps_dir, undefined),
+    case SharedDepsDir of
+        undefined ->
+            {false, undefined};
+        _ ->
+            Version = parse_version(Dep#dep.source),
+            UnversionedAppDir = filename:join(
+                [BaseDir, SharedDepsDir, Dep#dep.app]),
+            VersionedAppDir = get_download_dir(UnversionedAppDir, Version),
+            {true, VersionedAppDir}
+    end.
 
 get_lib_dir(App) ->
     %% Find App amongst the reachable lib directories
@@ -369,9 +451,16 @@ acc_deps(find, missing, Dep, AppDir, {Avail, Missing}) ->
 acc_deps(read, _, Dep, AppDir, Acc) ->
     [Dep#dep { dir = AppDir } | Acc].
 
-delete_dep(D) ->
+delete_dep(Config, D) ->
     case filelib:is_dir(D#dep.dir) of
         true ->
+            ok = case get_spil_shared_deps_dir(Config, D) of
+                {true, SharedDepDir} ->
+                    ?INFO("Deleting shared dependency: ~s\n", [SharedDepDir]),
+                    rebar_file_utils:rm_rf(SharedDepDir);
+                {false, _} ->
+                    ok
+            end,
             ?INFO("Deleting dependency: ~s\n", [D#dep.dir]),
             rebar_file_utils:rm_rf(D#dep.dir);
         false ->
@@ -382,10 +471,6 @@ require_source_engine(Source) ->
     true = source_engine_avail(Source),
     ok.
 
-%% IsRaw = false means regular Erlang/OTP dependency
-%%
-%% IsRaw = true means non-Erlang/OTP dependency, e.g. the one that does not
-%% have a proper .app file
 is_app_available(Config, App, VsnRegex, Path, _IsRaw = false) ->
     ?DEBUG("is_app_available, looking for App ~p with Path ~p~n", [App, Path]),
     case rebar_app_utils:is_app_dir(Path) of
@@ -397,14 +482,31 @@ is_app_available(Config, App, VsnRegex, Path, _IsRaw = false) ->
                           [App, VsnRegex, App, Vsn, Path]),
                     case re:run(Vsn, VsnRegex, [{capture, none}]) of
                         match ->
-                            {Config2, {true, Path}};
+                            {memoize_dependency(Config2, App, VsnRegex),
+                                {true, Path}};
                         nomatch ->
-                            ?WARN("~s has version ~p; requested regex was ~s\n",
-                                  [AppFile, Vsn, VsnRegex]),
-                            {Config2,
-                             {false, {version_mismatch,
-                                      {AppFile,
-                                       {expected, VsnRegex}, {has, Vsn}}}}}
+                            ?WARN("~s has version ~p; requested was ~1000p\n",
+                                [AppFile, Vsn, VsnRegex]),
+                            case can_resolve_dependency(
+                                    Config2, App, VsnRegex) of
+                                true ->
+                                    %% We need to clear the cache of the app_vsn
+                                    %% Because in a next round we probably have
+                                    %% a new version available in the directory
+                                    Config3 = rebar_app_utils:app_vsn_reset(
+                                        Config2,
+                                        AppFile
+                                    ),
+                                    {Config3,
+                                        {false, resolvable_version_mismatch}};
+                                {false, Reason} ->
+                                    {Config2,
+                                        {false, {version_mismatch,
+                                                {AppFile,
+                                                    {wanted, VsnRegex},
+                                                    {has, Vsn},
+                                                    Reason}}}}
+                            end
                     end;
                 {Config1, OtherApp} ->
                     ?WARN("~s has application id ~p; expected ~p\n",
@@ -418,8 +520,10 @@ is_app_available(Config, App, VsnRegex, Path, _IsRaw = false) ->
                   "but no .app found.\n", [Path]),
             {Config, {false, {missing_app_file, Path}}}
     end;
+
 is_app_available(Config, App, _VsnRegex, Path, _IsRaw = true) ->
-    ?DEBUG("is_app_available, looking for Raw Depencency ~p with Path ~p~n", [App, Path]),
+    ?DEBUG("is_app_available, looking for Raw Depencency ~p with Path ~p~n",
+        [App, Path]),
     case filelib:is_dir(Path) of
         true ->
             %% TODO: look for version string in <Path>/VERSION file? Not clear
@@ -433,38 +537,134 @@ is_app_available(Config, App, _VsnRegex, Path, _IsRaw = true) ->
     end.
 
 use_source(Config, Dep) ->
-    use_source(Config, Dep, 3).
+    use_source(Config, Dep, 3, false).
 
-use_source(_Config, Dep, 0) ->
+use_source(_Config, Dep, 0, _) ->
     ?ABORT("Failed to acquire source from ~p after 3 tries.\n",
            [Dep#dep.source]);
-use_source(Config, Dep, Count) ->
-    case filelib:is_dir(Dep#dep.dir) of
+use_source(Config, Dep, Count, Force) ->
+    case Force of
         true ->
-            %% Already downloaded -- verify the versioning matches the regex
-            case is_app_available(Config, Dep#dep.app,
-                                  Dep#dep.vsn_regex, Dep#dep.dir, Dep#dep.is_raw) of
-                {Config1, {true, _}} ->
-                    Dir = filename:join(Dep#dep.dir, "ebin"),
-                    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
-                    %% Available version matches up -- we're good to go;
-                    %% add the app dir to our code path
-                    true = code:add_patha(Dir),
-                    {Config1, Dep};
-                {_Config1, {false, Reason}} ->
-                    %% The app that was downloaded doesn't match up (or had
-                    %% errors or something). For the time being, abort.
-                    ?ABORT("Dependency dir ~s failed application validation "
-                           "with reason:~n~p.\n", [Dep#dep.dir, Reason])
-            end;
-        false ->
-            ?CONSOLE("Pulling ~p from ~p\n", [Dep#dep.app, Dep#dep.source]),
-            require_source_engine(Dep#dep.source),
-            {true, TargetDir} = get_deps_dir(Config, Dep#dep.app),
-            download_source(TargetDir, Dep#dep.source),
-            use_source(Config, Dep#dep { dir = TargetDir }, Count-1)
+            %% When forcing the retrieve, we need to make sure the directory
+            %% does not already exist
+            case filelib:is_dir(Dep#dep.dir) of
+                true ->
+                    rebar_file_utils:rm_rf(Dep#dep.dir);
+                false ->
+                    ok
+            end,
+            retrieve_source_and_retry(Config, Dep, Count, Force);
+        _ ->
+            case filelib:is_dir(Dep#dep.dir) of
+                true ->
+
+                    %% Already downloaded -- verify the versioning matches the
+                    %% regex
+                    case is_app_available(Config, Dep#dep.app,
+                                          Dep#dep.vsn_regex,
+                                          Dep#dep.dir, Dep#dep.is_raw) of
+                        {Config1, {false, resolvable_version_mismatch}} ->
+                            ?WARN("Dependency dir ~s failed version-check, but able to resolve.\n",
+                                   [Dep#dep.dir]),
+                            use_source(Config1, Dep, Count, true);
+                        {Config1, {true, _}} ->
+                            Dir = filename:join(Dep#dep.dir, "ebin"),
+                            ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+                            %% Available version matches up -- we're good to go;
+                            %% add the app dir to our code path
+                            true = code:add_patha(Dir),
+                            {Config1, Dep};
+                        {Config1, {false, Reason}} ->
+                            %% The app that was downloaded doesn't match up (or had
+                            %% errors or something).
+                            ?WARN("Dependency dir ~s failed application validation "
+                                   "with reason:~n~p.Will retry by removing previous deps dir.\n", [Dep#dep.dir, Reason]),
+                            rebar_file_utils:rm_rf(Dep#dep.dir),
+                            use_source(Config1, Dep, Count-1, true)
+                    end;
+                false ->
+                    retrieve_source_and_retry(Config, Dep, Count, Force)
+            end
     end.
 
+
+retrieve_source_and_retry(Config, Dep, Count, Force) ->
+    %% The shared deps dir might already exist, in that case we only
+    %% need to symlink. So construct the download dir and check if it
+    %% already exists.
+    {true, TargetDir} = get_deps_dir(Config, Dep#dep.app),
+    _ = case get_spil_shared_deps_dir(Config, Dep) of
+        {false, _} ->
+            download_dep(Dep, TargetDir);
+        {true, SharedTargetDir} ->
+            %% If the (possibly versioned) downloads dir already exists, just
+            %% skip downloading the source
+            case filelib:is_dir(SharedTargetDir) of
+                false ->
+                    download_dep(Dep, SharedTargetDir);
+                true ->
+                    case Force of
+                        true ->
+                            rebar_file_utils:rm_rf(SharedTargetDir),
+                            download_dep(Dep, SharedTargetDir);
+                        false ->
+                            ok
+                    end
+            end,
+            rebar_file_utils:rm_rf(TargetDir),
+            setup_deps_dir(Config, SharedTargetDir, TargetDir)
+    end,
+
+    Config1 = case rebar_app_utils:is_app_dir(Dep#dep.dir) of
+        {true, AppFile} ->
+            rebar_app_utils:app_vsn_reset(Config, AppFile);
+        _ ->
+            ?WARN("Failed to reload .app file for ~p.\n", [Dep#dep.app]),
+            Config
+    end,
+
+    use_source(Config1, Dep#dep { dir = TargetDir }, Count-1, false).
+
+%% Helper, downloads dependency from source
+download_dep(Dep, Destination) ->
+    ?CONSOLE("Pulling ~p from ~p\n", [Dep#dep.app, Dep#dep.source]),
+    require_source_engine(Dep#dep.source),
+    download_source(Destination, Dep#dep.source).
+
+%% Helper creates a versioned download
+get_download_dir(BaseAppDir, {branch, "HEAD"}) ->
+    BaseAppDir;
+get_download_dir(BaseAppDir, {branch, Branch}) ->
+    BaseAppDir ++ "-branch-" ++ Branch;
+get_download_dir(BaseAppDir, {tag, Tag}) ->
+    BaseAppDir ++ "-tag-" ++ Tag;
+get_download_dir(BaseAppDir, {rev, Rev}) ->
+    BaseAppDir ++ "-rev-" ++ Rev;
+get_download_dir(BaseAppDir, _) ->
+    BaseAppDir.
+
+%% Parse the version to a uniform format
+parse_version({hg, _, Rev}) ->
+    {rev, Rev};
+parse_version({git, Url}) ->
+    parse_version({git, Url, {branch, "HEAD"}});
+parse_version({git, Url, ""}) ->
+    parse_version({git, Url, {branch, "HEAD"}});
+parse_version({git, _, {branch, Branch}}) ->
+    {branch, Branch};
+parse_version({git, _, {tag, Tag}}) ->
+    {tag, Tag};
+parse_version({git, _, Rev}) ->
+    {rev, Rev};
+parse_version({bzr, _, Rev}) ->
+    {rev, Rev};
+parse_version({svn, _, Rev}) ->
+    {rev, Rev};
+parse_version(undefined) ->
+    undefined.
+
+
+%% Downloads the source and returns the directory containing the source.
 download_source(AppDir, {hg, Url, Rev}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("hg clone -U ~s ~s", [Url, filename:basename(AppDir)]),
@@ -566,6 +766,48 @@ update_source1(AppDir, {fossil, _Url, Version}) ->
     rebar_utils:sh("fossil pull", [{cd, AppDir}]),
     rebar_utils:sh(?FMT("fossil update ~s", [Version]), []).
 
+
+%% Remember downloaded dependencies
+memoize_dependency(Config, App, VsnCheck) ->
+    PreviousAppVersionRestrictions = get_value(Config, {dep,App}, []),
+
+    % Used to be: Config = get_value(config, undefined),
+    DepsConfig = get_value(Config, config, undefined),
+
+    % Was: Dir = rebar_config:get_dir(Config), (one got from get_value)
+    Dir = rebar_config:get_dir(DepsConfig),
+    NewAppVersionRestrictions =
+    [{Dir, VsnCheck}] ++ PreviousAppVersionRestrictions,
+    set_value(Config, {dep,App}, NewAppVersionRestrictions).
+
+%% Check if we can resolve this new dependency
+can_resolve_dependency(Config, App, VsnCheck) ->
+    AppDepConstraints = get_value(Config, {dep,App}, []),
+    VsnConstraints = [ Constraint || {_, Constraint} <- AppDepConstraints],
+    Res = check_dependencies(VsnCheck, VsnConstraints, true),
+    case Res of
+        false ->
+            {false, {reason, {cannot_satisfy, AppDepConstraints}}};
+        true ->
+            true
+    end.
+
+check_dependencies(_, _, false) ->
+    false;
+check_dependencies(_, [], Res) ->
+    Res;
+check_dependencies(Vsn, [H|T], _) ->
+    check_dependencies(Vsn, T, re:run(Vsn, H, [{capture, none}]) == match).
+
+get_value(Config, Key, Default) ->
+    DepsConfig = rebar_config:get_global(Config, rebar_deps_config, []),
+    proplists:get_value(Key, DepsConfig, Default).
+
+set_value(Config, Key, Value) ->
+    DepsConfig = rebar_config:get_global(Config, rebar_deps_config, []),
+    TempConfig = proplists:delete(Key, DepsConfig),
+    NewConfig = [{Key, Value}] ++ TempConfig,
+    rebar_config:set_global(Config, rebar_deps_config, NewConfig).
 
 %% ===================================================================
 %% Source helper functions

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -43,6 +43,7 @@
          expand_code_path/0,
          expand_env_variable/3,
          vcs_vsn/3,
+         vcs_vsn_delete/3,
          deprecated/3, deprecated/4,
          get_deprecated_global/4, get_deprecated_global/5,
          get_experimental_global/3, get_experimental_local/3,
@@ -212,6 +213,12 @@ vcs_vsn(Config, Vcs, Dir) ->
         {ok, VsnString} ->
             {Config, VsnString}
     end.
+
+vcs_vsn_delete(Config, Vcs, Dir) ->
+    Key = {Vcs, Dir},
+    Cache = rebar_config:get_xconf(Config, vsn_cache),
+    Cache1 = dict:erase(Key, Cache),
+    rebar_config:set_xconf(Config, vsn_cache, Cache1).
 
 get_deprecated_global(Config, OldOpt, NewOpt, When) ->
     get_deprecated_global(Config, OldOpt, NewOpt, undefined, When).


### PR DESCRIPTION
@yfyf @thijsterlouw @spil-enrique please do the final review of the PR so I can send it to the public.

It is impossible to share a single deps with many projects, because the
dependency directories are not versioned

Instead of downloading dependency xxx to a shared ../deps/xxx now we
download to a shared dependency dir (for example ../deps/xxx-tag-1.2.3)
and then add a symlink from our local deps dir to the version we want.

With the local symlink we avoid issues with naming/addressing versioned
directories and we make it explicit which libraries we are using, which
is a good thing in case the shared dependency directory is used by many
projects. It does mean we have two dependency directories: the local one
and the shared one, we can add a new option for the shared deps. If it
is set, then follow the new flow so it is backwards compatible.

Implementation:

```
add an option {shared_deps_dir, "../deps"} besides the currently available {deps_dir, "deps"}
via the OS environment REBAR_SHARED_DEPS_DIR we can set it globally
if shared_deps_dir is set, then we download into that directory and symlink from deps_dir to shared_deps_dir (and use deps_dir obviously)
if not set, use the current logic of version resolution (unversioned inside deps_dir)
```

Original implementation:
Thijs Terlouw Thijs.Terlouw@spilgames.com @thijsterlouw
With improvements from:
Ignas Vyšniauskas Ignas.Vysniauskas@spilgames.com @yfyf
Motiejus Jakštys Motiejus.Jakstys@spilgames.com

Original issue: basho/rebar#257
We have been using this for way more than a year and it works great for us. This feature is completely optional, however, it really saves time when working on codebases with lots of dependencies. Please consider merging.
